### PR TITLE
migrationfile 作成

### DIFF
--- a/db/migrate/20210321084544_create_messages.rb
+++ b/db/migrate/20210321084544_create_messages.rb
@@ -1,0 +1,10 @@
+class CreateMessages < ActiveRecord::Migration[6.0]
+  def change
+    create_table :messages do |t|
+      t.string :content, null: false
+      t.references :room, foreign_key: true
+      t.references :user, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_08_020758) do
+ActiveRecord::Schema.define(version: 2021_03_21_084544) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -44,7 +44,7 @@ ActiveRecord::Schema.define(version: 2021_03_08_020758) do
   end
 
   create_table "messages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "content"
+    t.string "content", null: false
     t.bigint "room_id"
     t.bigint "user_id"
     t.datetime "created_at", precision: 6, null: false


### PR DESCRIPTION
# What
message model を再度作成し、データベースのmessageテーブル再度作成

# Why
以前ローカルでマイグレーションファイルをstatus:UPのまま削除してしまっていたため
このままではHerokuのデータベースにmessageテーブルが作成されないことになるので作り直しました